### PR TITLE
Complete material ui migration across remaining pages

### DIFF
--- a/shop/src/app/[locale]/sales/layaway/page.tsx
+++ b/shop/src/app/[locale]/sales/layaway/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { Box, Button, Grid, Paper, Stack, Typography } from '@mui/material';
+import { DataTable } from '@/components/mui/DataTable';
+import { GridColDef } from '@mui/x-data-grid';
 
 type Row = { id: string; customerId?: string; createdAt: number; remaining: number; nextDueDate?: string; overdueDays: number; status: string };
 
@@ -28,62 +31,56 @@ export default function LayawayPage() {
     return () => { cancelled = true; };
   }, []);
 
+  const columns: GridColDef[] = useMemo(() => ([
+    { field: 'customerId', headerName: t('layaway.customer') || 'العميل', flex: 1 },
+    { field: 'remaining', headerName: t('layaway.remaining') || 'المتبقي', width: 140, valueFormatter: (p) => (p.value as number)?.toFixed?.(2) },
+    { field: 'nextDueDate', headerName: t('layaway.nextDue') || 'الاستحقاق التالي', width: 160, renderCell: (p) => (
+      <span dir="ltr">{p.value ? new Date(p.value as string).toLocaleDateString() : '-'}</span>
+    ) },
+    { field: 'overdueDays', headerName: t('layaway.overdueDays') || 'العمر', width: 120 },
+    { field: 'status', headerName: t('layaway.status') || 'الحالة', width: 140 },
+    { field: 'actions', headerName: '', width: 220, sortable: false, renderCell: (p) => (
+      <Stack direction="row" spacing={1} justifyContent="flex-end" sx={{ width: '100%' }}>
+        <Button variant="outlined" size="small">{t('layaway.collect') || 'تحصيل دفعة'}</Button>
+        <Button variant="outlined" size="small">{t('layaway.cancel') || 'إلغاء الحجز'}</Button>
+      </Stack>
+    ) },
+  ]), [t]);
+
   return (
-    <main className="p-4" dir="rtl">
-      <h1 className="text-xl font-semibold mb-3">{t('layaway.title') || 'تقسيط/الحجوزات'}</h1>
+    <Box component="main" sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }} dir="rtl">
+      <Typography variant="h6" fontWeight={600}>{t('layaway.title') || 'تقسيط/الحجوزات'}</Typography>
       {rollup && (
-        <div className="grid grid-cols-4 gap-2 mb-4 text-center">
-          <div className="rounded border p-2">
-            <div className="text-xs text-neutral-500">0–7</div>
-            <div className="font-semibold">{rollup['0-7'].toFixed(2)}</div>
-          </div>
-          <div className="rounded border p-2">
-            <div className="text-xs text-neutral-500">8–14</div>
-            <div className="font-semibold">{rollup['8-14'].toFixed(2)}</div>
-          </div>
-          <div className="rounded border p-2">
-            <div className="text-xs text-neutral-500">15–30</div>
-            <div className="font-semibold">{rollup['15-30'].toFixed(2)}</div>
-          </div>
-          <div className="rounded border p-2">
-            <div className="text-xs text-neutral-500">{t('layaway.over30') || 'أكثر من 30'}</div>
-            <div className="font-semibold">{rollup['>30'].toFixed(2)}</div>
-          </div>
-        </div>
+        <Grid container spacing={1}>
+          <Grid item xs={6} md={3}>
+            <Paper variant="outlined" sx={{ p: 1.5, textAlign: 'center' }}>
+              <Typography variant="caption" color="text.secondary">0–7</Typography>
+              <Typography fontWeight={600}>{rollup['0-7'].toFixed(2)}</Typography>
+            </Paper>
+          </Grid>
+          <Grid item xs={6} md={3}>
+            <Paper variant="outlined" sx={{ p: 1.5, textAlign: 'center' }}>
+              <Typography variant="caption" color="text.secondary">8–14</Typography>
+              <Typography fontWeight={600}>{rollup['8-14'].toFixed(2)}</Typography>
+            </Paper>
+          </Grid>
+          <Grid item xs={6} md={3}>
+            <Paper variant="outlined" sx={{ p: 1.5, textAlign: 'center' }}>
+              <Typography variant="caption" color="text.secondary">15–30</Typography>
+              <Typography fontWeight={600}>{rollup['15-30'].toFixed(2)}</Typography>
+            </Paper>
+          </Grid>
+          <Grid item xs={6} md={3}>
+            <Paper variant="outlined" sx={{ p: 1.5, textAlign: 'center' }}>
+              <Typography variant="caption" color="text.secondary">{t('layaway.over30') || 'أكثر من 30'}</Typography>
+              <Typography fontWeight={600}>{rollup['>30'].toFixed(2)}</Typography>
+            </Paper>
+          </Grid>
+        </Grid>
       )}
 
-      <div className="rounded border overflow-auto">
-        <table className="w-full text-sm">
-          <thead className="bg-neutral-50">
-            <tr>
-              <th className="p-2 text-right">{t('layaway.customer') || 'العميل'}</th>
-              <th className="p-2">{t('layaway.remaining') || 'المتبقي'}</th>
-              <th className="p-2">{t('layaway.nextDue') || 'الاستحقاق التالي'}</th>
-              <th className="p-2">{t('layaway.overdueDays') || 'العمر'}</th>
-              <th className="p-2">{t('layaway.status') || 'الحالة'}</th>
-              <th className="p-2"></th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((r) => (
-              <tr key={r.id} className="border-t">
-                <td className="p-2">{r.customerId || '-'}</td>
-                <td className="p-2">{r.remaining.toFixed(2)}</td>
-                <td className="p-2" dir="ltr">{r.nextDueDate ? new Date(r.nextDueDate).toLocaleDateString() : '-'}</td>
-                <td className="p-2">{r.overdueDays || 0}</td>
-                <td className="p-2">{r.status}</td>
-                <td className="p-2 text-left">
-                  <div className="flex gap-2 justify-end">
-                    <button className="px-2 py-1 rounded border">{t('layaway.collect') || 'تحصيل دفعة'}</button>
-                    <button className="px-2 py-1 rounded border">{t('layaway.cancel') || 'إلغاء الحجز'}</button>
-                  </div>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </main>
+      <DataTable rows={rows} columns={columns} loading={loading} getRowId={(r) => (r as Row).id} autoHeight />
+    </Box>
   );
 }
 

--- a/shop/src/app/admin/observability/page.tsx
+++ b/shop/src/app/admin/observability/page.tsx
@@ -1,4 +1,8 @@
-import { Suspense } from 'react';
+"use client";
+import { Suspense, useMemo } from 'react';
+import { Box, Paper, Typography } from '@mui/material';
+import { DataTable } from '@/components/mui/DataTable';
+import { GridColDef } from '@mui/x-data-grid';
 
 async function fetchSummary() {
   const res = await fetch('/api/obs/summary', { cache: 'no-store' });
@@ -8,86 +12,61 @@ async function fetchSummary() {
 
 function Cards({ data }: { data: any }) {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-3" dir="rtl">
-      <div className="rounded border p-3 bg-white"><div className="text-neutral-500 text-sm">أخطاء (24 ساعة)</div><div className="text-2xl font-bold">{data?.errors?.last24h || 0}</div></div>
-      <div className="rounded border p-3 bg-white"><div className="text-neutral-500 text-sm">الطلبات/الدقيقة</div><div className="text-2xl font-bold">—</div></div>
-      <div className="rounded border p-3 bg-white"><div className="text-neutral-500 text-sm">زمن الاستجابة P95</div><div className="text-2xl font-bold">—</div></div>
-    </div>
+    <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: 'repeat(3, 1fr)' }, gap: 1 }} dir="rtl">
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Typography variant="body2" color="text.secondary">أخطاء (24 ساعة)</Typography>
+        <Typography variant="h5" fontWeight={700}>{data?.errors?.last24h || 0}</Typography>
+      </Paper>
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Typography variant="body2" color="text.secondary">الطلبات/الدقيقة</Typography>
+        <Typography variant="h5" fontWeight={700}>—</Typography>
+      </Paper>
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Typography variant="body2" color="text.secondary">زمن الاستجابة P95</Typography>
+        <Typography variant="h5" fontWeight={700}>—</Typography>
+      </Paper>
+    </Box>
   );
 }
 
 function ErrorsTable({ items }: { items: any[] }) {
-  return (
-    <div className="overflow-x-auto" dir="rtl">
-      <table className="min-w-full text-sm">
-        <thead>
-          <tr className="text-right">
-            <th className="p-2">المعرف</th>
-            <th className="p-2">الوقت</th>
-            <th className="p-2">المسار</th>
-            <th className="p-2">الطريقة</th>
-            <th className="p-2">الملخص</th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((it:any)=> (
-            <tr key={it.id} className="border-t">
-              <td className="p-2">{it.id}</td>
-              <td className="p-2">{new Date(it.time).toLocaleString('ar-SA')}</td>
-              <td className="p-2">{it.route}</td>
-              <td className="p-2">{it.method}</td>
-              <td className="p-2">{it.summary}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
+  const columns: GridColDef[] = useMemo(() => ([
+    { field: 'id', headerName: 'المعرف', width: 200 },
+    { field: 'time', headerName: 'الوقت', width: 220, valueFormatter: (p) => new Date(p.value as number).toLocaleString('ar-SA') },
+    { field: 'route', headerName: 'المسار', flex: 1 },
+    { field: 'method', headerName: 'الطريقة', width: 120 },
+    { field: 'summary', headerName: 'الملخص', flex: 1.2 },
+  ]), []);
+  return <DataTable rows={items} columns={columns} getRowId={(r) => (r as any).id} autoHeight />;
 }
 
 function SlowQueriesTable({ items }: { items: any[] }) {
-  return (
-    <div className="overflow-x-auto" dir="rtl">
-      <table className="min-w-full text-sm">
-        <thead>
-          <tr className="text-right">
-            <th className="p-2">المجموعة</th>
-            <th className="p-2">العملية</th>
-            <th className="p-2">المدة (مللي ثانية)</th>
-            <th className="p-2">الوقت</th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((it:any, idx:number)=> (
-            <tr key={idx} className="border-t">
-              <td className="p-2">{it.collection}</td>
-              <td className="p-2">{it.op}</td>
-              <td className="p-2">{it.ms}</td>
-              <td className="p-2">{new Date(it.ts).toLocaleString('ar-SA')}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
+  const columns: GridColDef[] = useMemo(() => ([
+    { field: 'collection', headerName: 'المجموعة', width: 220 },
+    { field: 'op', headerName: 'العملية', width: 140 },
+    { field: 'ms', headerName: 'المدة (مللي ثانية)', width: 180 },
+    { field: 'ts', headerName: 'الوقت', width: 220, valueFormatter: (p) => new Date(p.value as number).toLocaleString('ar-SA') },
+  ]), []);
+  const withIds = items.map((it: any, idx: number) => ({ id: idx, ...it }));
+  return <DataTable rows={withIds} columns={columns} autoHeight />;
 }
 
 export default async function ObservabilityPage() {
   const data = await fetchSummary();
   return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-xl font-semibold" dir="rtl">المراقبة</h1>
+    <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Typography variant="h6" fontWeight={600} dir="rtl">المراقبة</Typography>
       <Suspense fallback={<div>...</div>}><Cards data={data} /></Suspense>
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <div>
-          <h2 className="font-semibold mb-2" dir="rtl">أحدث الأخطاء</h2>
+      <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', lg: '1fr 1fr' }, gap: 2 }}>
+        <Box>
+          <Typography fontWeight={600} mb={1} dir="rtl">أحدث الأخطاء</Typography>
           <ErrorsTable items={data?.errors?.latest || []} />
-        </div>
-        <div>
-          <h2 className="font-semibold mb-2" dir="rtl">استعلامات بطيئة</h2>
+        </Box>
+        <Box>
+          <Typography fontWeight={600} mb={1} dir="rtl">استعلامات بطيئة</Typography>
           <SlowQueriesTable items={data?.slowQueries || []} />
-        </div>
-      </div>
-    </div>
+        </Box>
+      </Box>
+    </Box>
   );
 }

--- a/shop/src/app/purchase-orders/[id]/page.tsx
+++ b/shop/src/app/purchase-orders/[id]/page.tsx
@@ -1,6 +1,21 @@
 "use client";
 import { use, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
+import {
+  Alert,
+  Box,
+  Button,
+  Grid,
+  Paper,
+  Snackbar,
+  Stack,
+  Tab,
+  Tabs,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { DataTable } from '@/components/mui/DataTable';
+import { GridColDef } from '@mui/x-data-grid';
 
 type ParsedLine = { code?: string; name?: string; size?: string; color?: string; quantity?: number; unitCost?: number; total?: number; raw?: string };
 
@@ -9,6 +24,7 @@ export default function POPage({ params }: { params: Promise<{ id: string }> }) 
   const [tab, setTab] = useState<'attachments'|'ocr'|'lines'>('attachments');
   const [review, setReview] = useState<Array<{ sku?: string; size?: string; color?: string; quantity: number; unitCost: number }>>([]);
   const [rawText, setRawText] = useState('');
+  const [snack, setSnack] = useState<{ open: boolean; message: string; severity: 'success'|'info'|'warning'|'error' }>({ open: false, message: '', severity: 'success' });
   const { id } = use(params);
 
   async function load() {
@@ -48,117 +64,126 @@ export default function POPage({ params }: { params: Promise<{ id: string }> }) 
     const lines = review.filter((l) => l.sku && l.quantity > 0);
     const res = await fetch(`/api/purchase-orders/${id}/receive`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ lines }) });
     if (res.ok) {
-      alert('تم الاستلام بنجاح');
+      setSnack({ open: true, message: 'تم الاستلام بنجاح', severity: 'success' });
       await load();
     }
   }
 
   const attachments = useMemo(() => po?.attachments || [], [po]);
 
-  return (
-    <div className="p-4" dir="rtl">
-      <div className="flex items-center justify-between mb-3">
-        <div>
-          <div className="text-sm text-gray-500">رقم الأمر</div>
-          <div className="text-xl font-semibold">{po?.poNumber}</div>
-        </div>
-        <div className="px-3 py-1 rounded-full border text-sm">{po && statusLabel(po.status)}</div>
-      </div>
+  const ocrColumns: GridColDef[] = useMemo(() => ([
+    { field: 'sku', headerName: 'الكود/الرمز', width: 160, renderCell: (p) => (
+      <TextField size="small" value={(p.row.sku || '') as string} onChange={(e) => {
+        const next = [...review];
+        next[p.row._idx].sku = e.target.value;
+        setReview(next);
+      }} />
+    ) },
+    { field: 'name', headerName: 'الاسم', width: 120, sortable: false, renderCell: () => (
+      <Typography color="text.secondary">—</Typography>
+    ) },
+    { field: 'size', headerName: 'المقاس', width: 120, renderCell: (p) => (
+      <TextField size="small" value={(p.row.size || '') as string} onChange={(e) => {
+        const next = [...review];
+        next[p.row._idx].size = e.target.value;
+        setReview(next);
+      }} />
+    ) },
+    { field: 'color', headerName: 'اللون', width: 120, renderCell: (p) => (
+      <TextField size="small" value={(p.row.color || '') as string} onChange={(e) => {
+        const next = [...review];
+        next[p.row._idx].color = e.target.value;
+        setReview(next);
+      }} />
+    ) },
+    { field: 'quantity', headerName: 'الكمية', width: 120, renderCell: (p) => (
+      <TextField size="small" type="number" value={Number(p.row.quantity)} onChange={(e) => {
+        const next = [...review];
+        next[p.row._idx].quantity = Number(e.target.value);
+        setReview(next);
+      }} />
+    ) },
+    { field: 'unitCost', headerName: 'سعر الوحدة', width: 140, renderCell: (p) => (
+      <TextField size="small" type="number" value={Number(p.row.unitCost)} onChange={(e) => {
+        const next = [...review];
+        next[p.row._idx].unitCost = Number(e.target.value);
+        setReview(next);
+      }} />
+    ) },
+    { field: 'total', headerName: 'الإجمالي', width: 140, valueGetter: (p) => (p.row.quantity * p.row.unitCost) || 0, valueFormatter: (p) => (Number(p.value) || 0).toFixed(2) },
+  ]), [review]);
 
-      <div className="flex gap-2 mb-4">
-        <button className={`px-3 py-2 rounded border ${tab==='attachments'?'bg-gray-100':''}`} onClick={()=>setTab('attachments')}>المرفقات</button>
-        <button className={`px-3 py-2 rounded border ${tab==='ocr'?'bg-gray-100':''}`} onClick={()=>setTab('ocr')}>المراجعة (OCR)</button>
-        <button className={`px-3 py-2 rounded border ${tab==='lines'?'bg-gray-100':''}`} onClick={()=>setTab('lines')}>البنود</button>
-      </div>
+  const ocrRows = useMemo(() => review.map((r, idx) => ({ ...r, _idx: idx, id: idx })), [review]);
+
+  const lineColumns: GridColDef[] = useMemo(() => ([
+    { field: 'sku', headerName: 'الكود', width: 160 },
+    { field: 'size', headerName: 'المقاس', width: 120 },
+    { field: 'color', headerName: 'اللون', width: 120 },
+    { field: 'quantityOrdered', headerName: 'الكمية المطلوبة', width: 160 },
+    { field: 'quantityReceived', headerName: 'المستلمة', width: 140 },
+    { field: 'unitCost', headerName: 'سعر الوحدة', width: 140, valueFormatter: (p) => (p.value == null ? '-' : Number(p.value).toFixed(2)) },
+  ]), []);
+
+  return (
+    <Box component="main" sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }} dir="rtl">
+      <Stack direction="row" alignItems="center" justifyContent="space-between">
+        <Box>
+          <Typography variant="caption" color="text.secondary">رقم الأمر</Typography>
+          <Typography variant="h6" fontWeight={600}>{po?.poNumber}</Typography>
+        </Box>
+        <Paper variant="outlined" sx={{ px: 1.5, py: 0.5 }}>
+          <Typography variant="body2">{po && statusLabel(po.status)}</Typography>
+        </Paper>
+      </Stack>
+
+      <Tabs value={tab} onChange={(_e, v) => setTab(v)} aria-label="PO tabs">
+        <Tab label="المرفقات" value="attachments" />
+        <Tab label="المراجعة (OCR)" value="ocr" />
+        <Tab label="البنود" value="lines" />
+      </Tabs>
 
       {tab==='attachments' && (
-        <div className="space-y-3">
-          <div className="text-sm">تحميل الفاتورة/الإيصال</div>
-          <input type="file" accept="image/*,.png,.jpg,.jpeg,.pdf,.txt" onChange={(e)=>{ const f=e.target.files?.[0]; if (f) onUpload(f); }} />
-          <div className="grid grid-cols-2 gap-3">
+        <Stack spacing={2}>
+          <Typography variant="body2">تحميل الفاتورة/الإيصال</Typography>
+          <Button variant="outlined" component="label">
+            اختر ملف
+            <input hidden type="file" accept="image/*,.png,.jpg,.jpeg,.pdf,.txt" onChange={(e)=>{ const f=e.target.files?.[0]; if (f) onUpload(f); }} />
+          </Button>
+          <Grid container spacing={1}>
             {attachments.map((u: string, i: number) => (
-              <a key={i} href={u} target="_blank" rel="noreferrer" className="block border rounded overflow-hidden">
-                <img src={u} alt="attachment" className="w-full object-contain" />
-              </a>
+              <Grid item xs={6} md={3} key={i}>
+                <Paper variant="outlined" sx={{ overflow: 'hidden' }}>
+                  <a href={u} target="_blank" rel="noreferrer">
+                    <img src={u} alt="attachment" style={{ width: '100%', objectFit: 'contain' }} />
+                  </a>
+                </Paper>
+              </Grid>
             ))}
-          </div>
-        </div>
+          </Grid>
+        </Stack>
       )}
 
       {tab==='ocr' && (
-        <div className="space-y-3">
-          <div className="text-sm">نص الإيصال</div>
-          <textarea value={rawText} onChange={(e)=>setRawText(e.target.value)} placeholder="ألصق النص المستخرج هنا (اختياري)" className="w-full h-32 border rounded p-2" />
-          <div className="flex gap-2">
-            <button className="px-3 py-2 rounded bg-blue-600 text-white" onClick={onParse}>قراءة النص (OCR)</button>
-            <button className="px-3 py-2 rounded bg-emerald-600 text-white" onClick={onReceive}>تأكيد الاستلام</button>
-          </div>
-          <div className="overflow-auto border rounded">
-            <table className="min-w-full text-right">
-              <thead className="bg-gray-50 sticky top-0">
-                <tr>
-                  <th className="p-2">الكود/الرمز</th>
-                  <th className="p-2">الاسم</th>
-                  <th className="p-2">المقاس</th>
-                  <th className="p-2">اللون</th>
-                  <th className="p-2">الكمية</th>
-                  <th className="p-2">سعر الوحدة</th>
-                  <th className="p-2">الإجمالي</th>
-                </tr>
-              </thead>
-              <tbody>
-                {review.map((r, idx) => (
-                  <tr key={idx} className="border-t">
-                    <td className="p-2"><input value={r.sku || ''} onChange={(e)=>{ const next=[...review]; next[idx].sku=e.target.value; setReview(next); }} className="border rounded px-2 py-1 w-40"/></td>
-                    <td className="p-2 text-gray-400">—</td>
-                    <td className="p-2"><input value={r.size || ''} onChange={(e)=>{ const next=[...review]; next[idx].size=e.target.value; setReview(next); }} className="border rounded px-2 py-1 w-24"/></td>
-                    <td className="p-2"><input value={r.color || ''} onChange={(e)=>{ const next=[...review]; next[idx].color=e.target.value; setReview(next); }} className="border rounded px-2 py-1 w-24"/></td>
-                    <td className="p-2"><input type="number" value={r.quantity} onChange={(e)=>{ const next=[...review]; next[idx].quantity=Number(e.target.value); setReview(next); }} className="border rounded px-2 py-1 w-20"/></td>
-                    <td className="p-2"><input type="number" value={r.unitCost} onChange={(e)=>{ const next=[...review]; next[idx].unitCost=Number(e.target.value); setReview(next); }} className="border rounded px-2 py-1 w-24"/></td>
-                    <td className="p-2">{(r.quantity*r.unitCost||0).toFixed(2)}</td>
-                  </tr>
-                ))}
-                {review.length===0 && (
-                  <tr><td colSpan={7} className="p-3 text-sm text-gray-500">أضف ملفًا أو الصق نص الإيصال لبدء المراجعة</td></tr>
-                )}
-              </tbody>
-            </table>
-          </div>
-        </div>
+        <Stack spacing={2}>
+          <Typography variant="body2">نص الإيصال</Typography>
+          <TextField value={rawText} onChange={(e)=>setRawText(e.target.value)} placeholder="ألصق النص المستخرج هنا (اختياري)" multiline minRows={6} />
+          <Stack direction="row" spacing={1}>
+            <Button variant="contained" onClick={onParse}>قراءة النص (OCR)</Button>
+            <Button variant="contained" color="success" onClick={onReceive}>تأكيد الاستلام</Button>
+          </Stack>
+          <DataTable rows={ocrRows} columns={ocrColumns} autoHeight />
+          {review.length===0 && (
+            <Typography variant="body2" color="text.secondary">أضف ملفًا أو الصق نص الإيصال لبدء المراجعة</Typography>
+          )}
+        </Stack>
       )}
 
       {tab==='lines' && (
-        <div className="overflow-auto border rounded">
-          <table className="min-w-full text-right">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="p-2">الكود</th>
-                <th className="p-2">المقاس</th>
-                <th className="p-2">اللون</th>
-                <th className="p-2">الكمية المطلوبة</th>
-                <th className="p-2">المستلمة</th>
-                <th className="p-2">سعر الوحدة</th>
-              </tr>
-            </thead>
-            <tbody>
-              {(po?.lines||[]).map((l: any, i: number) => (
-                <tr key={i} className="border-t">
-                  <td className="p-2">{l.sku || '-'}</td>
-                  <td className="p-2">{l.size || '-'}</td>
-                  <td className="p-2">{l.color || '-'}</td>
-                  <td className="p-2">{l.quantityOrdered || '-'}</td>
-                  <td className="p-2">{l.quantityReceived || '-'}</td>
-                  <td className="p-2">{l.unitCost?.toFixed?.(2) || '-'}</td>
-                </tr>
-              ))}
-              {(po?.lines||[]).length===0 && (
-                <tr><td colSpan={6} className="p-3 text-sm text-gray-500">لا توجد بنود</td></tr>
-              )}
-            </tbody>
-          </table>
-          <div className="p-2 border-t flex justify-end">
-            <button
-              className="px-3 py-2 rounded border"
+        <Stack spacing={1}>
+          <DataTable rows={(po?.lines||[]).map((l:any, i:number)=>({ id:i, ...l }))} columns={lineColumns} autoHeight />
+          <Stack direction="row" justifyContent="flex-end" sx={{ pt: 1 }}>
+            <Button
+              variant="outlined"
               onClick={async () => {
                 const received = (po?.lines||[])
                   .filter((l: any) => (l.quantityReceived||0) > 0 && l.sku)
@@ -172,9 +197,9 @@ export default function POPage({ params }: { params: Promise<{ id: string }> }) 
                     barcode: l.barcode,
                     brand: po?.supplier || undefined,
                   }));
-                if (received.length === 0) { alert('لا توجد بنود مستلمة'); return; }
+                if (received.length === 0) { setSnack({ open: true, severity: 'info', message: 'لا توجد بنود مستلمة' }); return; }
                 const res = await fetch('/api/labels/preview', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ template: 'thermal-80', items: received, options: { barcodeType: 'auto', show: { name: true, sku: true, sizeColor: true, price: true } } }) });
-                if (!res.ok) { alert('تعذر توليد الملصقات'); return; }
+                if (!res.ok) { setSnack({ open: true, severity: 'error', message: 'تعذر توليد الملصقات' }); return; }
                 const blob = await res.blob();
                 const url = URL.createObjectURL(blob);
                 const popup = window.open(url, '_blank');
@@ -182,15 +207,19 @@ export default function POPage({ params }: { params: Promise<{ id: string }> }) 
               }}
             >
               طباعة ملصقات للبنود المستلمة
-            </button>
-          </div>
-        </div>
+            </Button>
+          </Stack>
+        </Stack>
       )}
 
-      <div className="mt-4">
-        <Link href="/purchase-orders" className="text-blue-600">عودة للقائمة</Link>
-      </div>
-    </div>
+      <Stack sx={{ mt: 2 }}>
+        <Button component={Link as any} href="/purchase-orders" variant="text">عودة للقائمة</Button>
+      </Stack>
+
+      <Snackbar open={snack.open} autoHideDuration={4000} onClose={() => setSnack({ ...snack, open: false })} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
+        <Alert onClose={() => setSnack({ ...snack, open: false })} severity={snack.severity} variant="filled" sx={{ width: '100%' }}>{snack.message}</Alert>
+      </Snackbar>
+    </Box>
   );
 }
 


### PR DESCRIPTION
Migrate products import, layaway, admin audit, and purchase orders pages to Material UI components and DataGrid for UI standardization and consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f835808-70f3-47aa-9441-714089f220f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f835808-70f3-47aa-9441-714089f220f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

